### PR TITLE
GLM-42

### DIFF
--- a/tools/database_tools/db_cleanup.js
+++ b/tools/database_tools/db_cleanup.js
@@ -1,0 +1,20 @@
+print('Cleaning stale matches...');
+let date = new Date();
+let daysToDeletion = 1;
+let deletionDate = new Date(date.setDate(date.getDate() - daysToDeletion));
+
+var db = db.getSiblingDB('kjapp_game_lobby');
+db.getMongo().setSlaveOk();
+
+let matches = db.matches.find({});
+let matchesForDeletion = [];
+matches.forEach(element => {
+    if(element._id.getTimestamp() < deletionDate) {
+        matchesForDeletion.push(element);
+    }
+});
+
+print(`Deleting ${matchesForDeletion.length} stale entries from the DB`);
+matchesForDeletion.forEach(element => {
+    db.matches.remove({_id: element._id});
+});


### PR DESCRIPTION
Added a JS/Mongo script that cleans all matches that are older than one day. This script can be run using "mongo localhost:27017/kjapp_game_lobby tools/database_tools/db_cleanup.js".
To make this script run daily we need to setup a crontab on the server so I would recommend doing so after this sprints changes are pushed to master.

 #time 47m
 #partial-finish